### PR TITLE
Fix requests call and adds get_model_versions()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ node_modules/
 
 # PyCharm
 .idea/
+
+#jupyter
+.ipynb_checkpoints
+

--- a/oresapi/about.py
+++ b/oresapi/about.py
@@ -1,5 +1,5 @@
 __name__ = "oresapi"
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __author__ = "Aaron Halfaker"
 __author_email__ = "ahalfaker@wikimedia.org"
 __description__ = "A set of utilities for efficiently querying the ORES api."


### PR DESCRIPTION
Added method for retrieving model versions and adjusted requests call to use a context manager.

Per the [requests documentation](https://docs.python-requests.org/en/master/user/advanced/#body-content-workflow):

> If you set `stream` to `True` when making a request, Requests cannot release the connection back to the pool unless you consume all the data or call Response.close. This can lead to inefficiency with connections. If you find yourself partially reading request bodies (or not reading them at all) while using `stream=True`, you should make the request within a with statement to ensure it’s always closed.

I observed that when using the ThreadPoolExecutor, sudden shutdowns (such as those induced by KeyboardInterrupts) could make the request session unhappy. Using a context manager is a simple fix.

No real reason to merge this PR; this may be more of an FYI, since I'm not sure the version retrieval method is broadly useful.